### PR TITLE
feature(preprocess): add config-driven pipeline using ColumnTransformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Thumbs.db
 
 # GitHub Codespaces Python interpreter
 python-language-server.cache/
+
+*.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
     hooks:
       - id: mypy
         language_version: python3.12
+        args: ["--config-file=pyproject.toml"]
+        additional_dependencies: ["pydantic", "types-PyYAML", "pytest"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "readmitrx"
+version = "0.1.0"
+description = "ReadmitRx: ED readmission prediction pipeline"
+authors = [{ name = "ReadmitRx Team" }]
+dependencies = [
+    "scikit-learn>=1.6",
+    "pandas>=2.2",
+    "numpy>=2.2",
+    "pydantic>=2.11",
+    "pyyaml"
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["readmitrx"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+explicit_package_bases = true
+
+[[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "sklearn.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pydantic"
+ignore_missing_imports = true

--- a/readmitrx/config/feature_config.yaml
+++ b/readmitrx/config/feature_config.yaml
@@ -1,0 +1,54 @@
+# readmitrx/config/feature_config.yaml
+
+features:
+  num__:
+    - age
+    - risk_condition_count
+    - sdoh_alcohol_risk
+    - sdoh_substance_risk
+    - sdoh_emotional_support_score
+    - days_until_event
+    - total_contact_attempts
+    - time_spent_minutes
+    - tme_spent_total
+    - employment_status_code
+    - total_flags
+  cat__:
+    - None  # Add categorical codes here if available later
+  bin__:
+    - sex_female
+    - race_black
+    - race_hispanic
+    - race_other
+    - language_non_english
+    - has_comorbidity
+    - hypertension
+    - diabetes
+    - asthma
+    - is_new_patient
+    - spoke_to_subject
+    - engaged
+    - referral_type_ed
+    - referral_type_high_risk
+    - referral_type_other
+    - insurance_na
+    - insurance_public
+    - insurance_uninsured
+    - has_pcp_flag
+    - has_insurance_flag
+    - housing_insecure_flag
+    - housing_insecure_secondary
+    - fod_insecure_flag
+    - utility_insecure_flag
+    - transportation_barrier_flag
+    - domestic_violence_risk
+    - hiv_test_interest
+    - covid_vaccine_signup
+    - health_education_needed
+    - sdoh_responded
+    - has_unmet_needs
+    - referrals_made
+    - readmit_within_30
+    - is_high_risk
+  text__:
+    - None  # Add free-text fields if introduced later

--- a/readmitrx/config/load_config.py
+++ b/readmitrx/config/load_config.py
@@ -1,0 +1,47 @@
+# readmitrx/config/load_config.py
+
+"""
+load_config.py — Utility to load model feature configuration from YAML.
+
+Loads config from `readmitrx/config/feature_config.yaml` and parses feature groups
+into a structured dictionary.
+
+Returns:
+    A dictionary with keys: 'num', 'cat', 'bin', 'text'
+
+Example:
+    >>> from readmitrx.config.load_config import load_feature_config
+    >>> config = load_feature_config()
+    >>> print(config["num"])
+    ['age', 'risk_condition_count', 'sdoh_alcohol_risk']
+
+Author: ReadmitRx Project Team (2025)
+"""
+
+import yaml
+from pathlib import Path
+from typing import Dict, List
+
+from readmitrx.config.paths import FEATURE_CONFIG_PATH
+
+
+def load_feature_config(
+    config_path: Path = FEATURE_CONFIG_PATH,
+) -> Dict[str, List[str]]:
+
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+
+        features = config.get("features", {})
+        feature_dict = {
+            "num": features.get("num__", []) or [],
+            "cat": features.get("cat__", []) or [],
+            "bin": features.get("bin__", []) or [],
+            "text": features.get("text__", []) or [],
+        }
+
+    return feature_dict
+
+
+if __name__ == "__main__":
+    print(load_feature_config())

--- a/readmitrx/config/paths.py
+++ b/readmitrx/config/paths.py
@@ -1,0 +1,11 @@
+"""
+Configuration module
+
+"""
+
+from pathlib import Path
+
+CONFIG_DIR = Path(__file__).parent
+
+# Feature configuration path
+FEATURE_CONFIG_PATH = CONFIG_DIR / "feature_config.yaml"

--- a/readmitrx/pipeline/preprocess.py
+++ b/readmitrx/pipeline/preprocess.py
@@ -1,94 +1,90 @@
 """
-preprocess.py — Data cleaning and feature engineering for ReadmitRx pipeline.
+preprocess.py — Config-driven preprocessing pipeline for ReadmitRx.
 
-This module transforms raw ED visit data into a cleaned format suitable
-for ML model training and inference. It uses schema-aligned transformations
-based on the `RawEDVisit` and `CleanedEDVisit` models.
+Builds a modular, domain-agnostic sklearn pipeline that transforms raw input
+features into model-ready format. Feature groups are loaded from YAML config
+defined in `readmitrx/config/feature_config.yaml`.
 
 Features:
-- Parses dates and extracts visit month
-- Derives chronic condition flags
-- Creates binary target (`readmit_within_30`)
-- Handles missing values and type conversions
-
-Intended Use:
-- Called in training and inference workflows before modeling
+- Handles numerical, categorical, binary, and text columns
+- Uses ColumnTransformer and scikit-learn primitives
+- Designed to be composed into larger training/inference pipelines
 
 Inputs:
-- DataFrame containing raw features from the de-identified ED dataset
+- Pandas DataFrame matching the RawVisit schema
 
 Outputs:
-- DataFrame compatible with `CleanedEDVisit` schema
-
-Functions:
-- preprocess_ed_visits(df: pd.DataFrame) -> pd.DataFrame
+- Unfitted sklearn Pipeline object with preprocessing logic
 
 Example:
-    >>> from readmitrx.pipeline.preprocess import preprocess_ed_visits
-    >>> cleaned_df = preprocess_ed_visits(raw_df)
+    >>> from readmitrx.pipeline.preprocess import build_preprocessing_pipeline
+    >>> pipeline = build_preprocessing_pipeline()
+    >>> X_transformed = pipeline.fit_transform(X_raw)
 
 Author: ReadmitRx Project Team (2025)
 """
 
-import logging
-import pandas as pd
+from sklearn.pipeline import Pipeline
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import StandardScaler, OneHotEncoder, FunctionTransformer
+from sklearn.impute import SimpleImputer
 
-# Initialize logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from readmitrx.config.load_config import load_feature_config
 
 
-def preprocess_ed_visits(df: pd.DataFrame) -> pd.DataFrame:
+def build_preprocessing_pipeline() -> Pipeline:
     """
-    Preprocess raw ED visit data into a cleaned DataFrame.
-
-    Args:
-        df (pd.DataFrame): Raw ED dataset.
+    Builds a ColumnTransformer-based sklearn pipeline using config-defined feature types.
 
     Returns:
-        pd.DataFrame: Cleaned and feature-engineered DataFrame.
+        sklearn.pipeline.Pipeline: A pipeline that transforms raw features into model-ready format
     """
 
-    df = df.copy()
+    config = load_feature_config()
 
-    # Handle missing values
-    df["age"] = df["age"].fillna(df["age"].median())
-    df["sex_gender"] = df["sex_gender"].fillna("Unknown")
-    df["language"] = df["language"].fillna("Unknown")
+    num_features = config.get("num", [])
+    cat_features = config.get("cat", [])
+    bin_features = config.get("bin", [])
+    text_features = config.get("text", [])
 
-    # Processing chronic conditions
-    chronic_cols = ["hypertension", "asthma", "diabetes"]
-    for col in chronic_cols:
-        df[col] = df[col].fillna(0).astype(bool)
+    transformers = []
 
-    # Create has_chronic_condition flag
-    df["has_chronic_condition"] = df[chronic_cols].any(axis=1)
+    if num_features:
+        num_pipeline = Pipeline(
+            [("imputer", SimpleImputer(strategy="medium")), ("scalar", StandardScaler)]
+        )
+        transformers.append(("num", num_pipeline, num_features))
 
-    # Parse date and extract visit month
-    df["referral_date"] = pd.to_datetime(df["referral_date"], errors="coerce")
-    df["visit_month"] = df["referral_date"].dt.month
+    if cat_features and cat_features[0] is not None:
+        cat_pipeline = Pipeline(
+            [
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                ("encoder", OneHotEncoder(handle_unknown="ignore")),
+            ]
+        )
+        transformers.append(("cat", cat_pipeline, cat_features))
 
-    # Derive binary readmission target
-    df["readmit_within_30"] = df["day_readmit"].apply(
-        lambda x: bool(x <= 30) if pd.notnull(x) else False
+    if bin_features:
+        bin_pipeline = Pipeline(
+            [
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                ("identity", FunctionTransformer(validate=False)),
+            ]
+        )
+        transformers.append(("bin", bin_pipeline, bin_features))
+
+    if text_features and text_features[0] is not None:
+        text_pipeline = Pipeline([("identity", FunctionTransformer(validate=False))])
+        transformers.append(("text", text_pipeline, text_features))
+
+    preprocessor = ColumnTransformer(
+        transformers=transformers, remainder="drop", verbose_feature_names_out=False
     )
 
-    return df[
-        [
-            "record_id",
-            "redcap_event_name",
-            "new_patient",
-            "age",
-            "sex_gender",
-            "latino",
-            "language",
-            "hypertension",
-            "asthma",
-            "diabetes",
-            "referral_date",
-            "day_readmit",
-            "has_chronic_condition",
-            "visit_month",
-            "readmit_within_30",
-        ]
-    ]
+    pipeline = Pipeline([("preprocessor", preprocessor)])
+
+    return pipeline
+
+
+if __name__ == "__main__":
+    print(build_preprocessing_pipeline())

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ pre-commit>=3.6
 
 pandas-stubs>=2.2.3
 networkx==3.3
+types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,6 +161,8 @@ triton==2.2.0
     # via torch
 types-pytz==2025.2.0.20250516
     # via pandas-stubs
+types-pyyaml==6.0.12.20250516
+    # via -r requirements.in
 typing-extensions==4.13.2
     # via
     #   -r requirements.in

--- a/tests/test_feature_config.py
+++ b/tests/test_feature_config.py
@@ -1,0 +1,39 @@
+# tests/test_feature_config.py
+
+"""
+Unit tests for feature config loader and structure.
+
+Validates:
+- Correct keys in feature_config.yaml
+- All features are non-empty strings
+- No None or empty values in any group
+"""
+
+import pytest
+
+from readmitrx.config.load_config import load_feature_config
+
+
+def test_feature_config_keys_present() -> None:
+    config = load_feature_config()
+    assert isinstance(config, dict), "Config should be a dictionary"
+    assert set(config.keys()) == {
+        "num",
+        "cat",
+        "bin",
+        "text",
+    }, "Expected keys: num, cat, bin, text"
+
+
+@pytest.mark.parametrize("group", ["num", "cat", "bin", "text"])
+def test_feature_values_are_strings(group: str) -> None:
+    config = load_feature_config()
+    for feature in config[group]:
+        assert isinstance(feature, str), f"{feature} in '{group}' must be a string"
+        assert feature.strip() != "", f"{feature} in '{group} must not be empty"
+
+
+def test_no_none_values_in_any_group() -> None:
+    config = load_feature_config()
+    for group, features in config.items():
+        assert None not in features, f"'None' found in group: {group}"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -8,7 +8,7 @@ from readmitrx.core.schemas import (
 )
 
 
-def test_raw_visit_instantiation():
+def test_raw_visit_instantiation() -> None:
     visit = RawVisit(
         age=45,
         sex_female=True,
@@ -25,7 +25,7 @@ def test_raw_visit_instantiation():
     assert visit.is_new_patient is True
 
 
-def test_cleaned_visit_extends_raw():
+def test_cleaned_visit_extends_raw() -> None:
     visit = CleanedVisit(
         age=60,
         hypertension=True,
@@ -39,7 +39,7 @@ def test_cleaned_visit_extends_raw():
     assert visit.total_flags == 2
 
 
-def test_clustered_visit_extends_cleaned():
+def test_clustered_visit_extends_cleaned() -> None:
     visit = ClusteredVisit(
         age=30,
         asthma=True,
@@ -50,7 +50,7 @@ def test_clustered_visit_extends_cleaned():
     assert not visit.readmit_within_30
 
 
-def test_prediction_result_schema():
+def test_prediction_result_schema() -> None:
     result = PredictionResult(
         record_id=123,
         risk_score=0.92,


### PR DESCRIPTION
### Summary

This PR introduces the core preprocessing pipeline for ReadmitRx, implemented in a modular, config-driven manner using scikit-learn's `ColumnTransformer`.

### Key Changes

- Added `feature_config.yaml` to define model input features by type (num, cat, bin, text)
- Implemented `load_config.py` to load and parse feature config
- Built `preprocess.py` to construct a modular pipeline using `SimpleImputer`, `StandardScaler`, and `OneHotEncoder`
- Centralized config paths using `paths.py` for maintainability
- Wrote unit tests in `test_feature_config.py` to validate config structure and ensure robustness
- Enabled full CI compatibility: passes `mypy`, `pytest`, `ruff`, and `pre-commit` hooks

### Testing

- `make check`: 
- `make test`: 
- `pre-commit run --all-files`: 
