### PR TITLE
featture(Feature-engineering): implement visit_month and chronic_count feature engineering with tests

### DIFF
--- a/.dev/initial_project_Setup.md
+++ b/.dev/initial_project_Setup.md
@@ -122,3 +122,8 @@ jobs:
       - name: Run pre-commit checks
         run: pre-commit run --all-files
 ```
+
+
+```bash
+tree readmitrx/ -L 2
+```

--- a/readmitrx/config/feature_config.yaml
+++ b/readmitrx/config/feature_config.yaml
@@ -7,14 +7,14 @@ features:
     - sdoh_alcohol_risk
     - sdoh_substance_risk
     - sdoh_emotional_support_score
-    - days_until_event
     - total_contact_attempts
     - time_spent_minutes
     - tme_spent_total
     - employment_status_code
     - total_flags
-  cat__:
-    - None  # Add categorical codes here if available later
+
+  cat__: []
+
   bin__:
     - sex_female
     - race_black
@@ -48,7 +48,6 @@ features:
     - sdoh_responded
     - has_unmet_needs
     - referrals_made
-    - readmit_within_30
     - is_high_risk
-  text__:
-    - None  # Add free-text fields if introduced later
+
+  text__: []

--- a/readmitrx/core/schemas.py
+++ b/readmitrx/core/schemas.py
@@ -43,7 +43,6 @@ class RawVisit(BaseModel):
     """
 
     # Demographics
-
     age: Optional[int] = None
     sex_female: Optional[bool] = None
     race_black: Optional[bool] = None
@@ -62,8 +61,8 @@ class RawVisit(BaseModel):
     sdoh_emotional_support_score: Optional[int] = None
 
     # Visit metadata
-    days_until_event: Optional[int] = None
     is_new_patient: Optional[bool] = None
+    visit_date: Optional[str] = None
 
     # Contact & engagement
     total_contact_attempts: Optional[int] = None
@@ -81,8 +80,8 @@ class RawVisit(BaseModel):
     insurance_uninsured: Optional[bool] = None
     has_pcp_flag: Optional[bool] = None
     has_insurance_flag: Optional[bool] = None
-    # SDoH needs
 
+    # SDoH needs
     housing_insecure_flag: Optional[bool] = None
     housing_insecure_secondary: Optional[bool] = None
     fod_insecure_flag: Optional[bool] = None
@@ -106,12 +105,10 @@ class CleanedVisit(RawVisit):
         RawVisit
 
     Adds:
-    - readmit_within_30: Binary outcome for model training (e.g. churn or readmission)
     - is_high_risk: Composite rule-based flag (optional)
     - total_flags: Count of triggered risk indicators (SDoH, comorbidities, etc.)
     """
 
-    readmit_within_30: Optional[bool] = None
     is_high_risk: Optional[bool] = None
     total_flags: Optional[int] = None
 

--- a/readmitrx/pipeline/feature_engineering.py
+++ b/readmitrx/pipeline/feature_engineering.py
@@ -1,0 +1,82 @@
+"""
+feature_engineering.py — Derived feature creation pipeline for ReadmitRx.
+
+This module contains reusable logic for deriving higher-level features from raw input data.
+It supports both domain-agnostic and domain-informed transformation logic, allowing decoupling
+from the preprocessing and model pipeline.
+
+Features:
+- Modular feature creation functions for date extraction and risk indicators
+- Clean separation from sklearn preprocessing logic
+- Logging-enabled for visibility during feature pipeline execution
+
+Intended Use:
+- Derive features such as:
+    - `visit_month`: calendar month of referral
+    - `has_chronic_condition`: flag if any chronic illness present
+    - `chronic_count`: number of chronic conditions
+
+Inputs:
+- Raw Pandas DataFrame with source columns (e.g., `referral_date`, `has_diabetes_flag`)
+
+Outputs:
+- Enriched DataFrame with added derived features
+
+Functions:
+- add_visit_month(df)
+- add_has_chronic_condition(df)
+- add_chronic_count(df)
+- apply_feature_engineering(df)
+
+Example Usage:
+    >>> df = pd.read_csv("sinai_synthetic_data.csv")
+    >>> df = apply_feature_engineering(df)
+
+Author: ReadmitRx Project Team (2025)
+"""
+
+import pandas as pd
+from typing import List, Optional
+
+from readmitrx.utils.logging import configure_logging
+
+# Initialize logger
+logger = configure_logging(
+    log_name="feature_engineering", log_file="feature_engineering.log"
+)
+
+
+def add_visit_month(df: pd.DataFrame) -> pd.DataFrame:
+    logger.info("Deriving feature: vist_month from visit_date")
+    df["visit_date"] = pd.to_datetime(df["visit_date"], errors="coerce")
+    df["visit_month"] = df["visit_date"].dt.month.fillna(0).astype(int)
+    logger.debug(f"visit_month values: {df['visit_month'].unique().tolist()}")
+    return df
+
+
+def add_chornic_count(
+    df: pd.DataFrame, chronic_fields: Optional[List[str]] = None
+) -> pd.DataFrame:
+    logger.info("Deriving feature: chronic_count")
+    if chronic_fields is None:
+        chronic_fields = [
+            "has_asthma_flag",
+            "has_diabetes_flag",
+            "has_hypertension_flag",
+        ]
+
+        df["chronic_count"] = df[chronic_fields].fillna(0).astype(int).sum(axis=1)
+        logger.debug(
+            f"chronic_count stats: min={df['chronic_count'].min()}, max={df['chronic_count'].max()}"
+        )
+    return df
+
+
+def apply_feature_engineering(df: pd.DataFrame) -> pd.DataFrame:
+    logger.info("Applying full feature engineering pipeline")
+    df = add_visit_month(df)
+    df = add_chornic_count(df)
+    logger.info(
+        f"Feature engineering complete. Columns now include : {list(df.columns)}"
+    )
+    return df

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,53 @@
+"""
+test_feature_engineering.py — Unit tests for derived feature creation logic.
+
+Tests:
+- visit_month is correctly extracted from visit_date
+- chronic_count correctly tallies chronic flags
+- apply_feature_engineering executes full feature stack
+
+Author: ReadmitRx Project Team (2025)
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+
+from readmitrx.pipeline.feature_engineering import (
+    add_chornic_count,
+    add_visit_month,
+    apply_feature_engineering,
+)
+
+
+@pytest.fixture
+def sample_input_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "visit_date": ["2024-01-15", "2024-06-03", None],
+            "has_asthma_flag": [1, 1, np.nan],
+            "has_diabetes_flag": [0, 1, 1],
+            "has_hypertension_flag": [1, 1, 1],
+        }
+    )
+
+
+def test_add_visit_month(sample_input_df: pd.DataFrame) -> None:
+    df = add_visit_month(sample_input_df.copy())
+    assert "visit_month" in df.columns
+    assert df["visit_month"].iloc[0] == 1
+    assert df["visit_month"].iloc[1] == 6
+    assert df["visit_month"].iloc[2] == 0
+
+
+def test_add_chronic_count(sample_input_df: pd.DataFrame) -> None:
+    df = add_chornic_count(sample_input_df.copy())
+    assert "chronic_count" in df.columns
+    assert df["chronic_count"].tolist() == [2, 3, 2]
+
+
+def test_apply_feature_engineering(sample_input_df: pd.DataFrame) -> None:
+    df = apply_feature_engineering(sample_input_df.copy())
+    assert "visit_month" in df.columns
+    assert "chronic_count" in df.columns
+    assert df.shape[0] == sample_input_df.shape[0]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -31,11 +31,10 @@ def test_cleaned_visit_extends_raw() -> None:
         hypertension=True,
         is_new_patient=False,
         total_contact_attempts=3,
-        readmit_within_30=True,
         total_flags=2,
         is_high_risk=True,
     )
-    assert visit.readmit_within_30
+    assert visit.is_high_risk
     assert visit.total_flags == 2
 
 
@@ -43,11 +42,9 @@ def test_clustered_visit_extends_cleaned() -> None:
     visit = ClusteredVisit(
         age=30,
         asthma=True,
-        readmit_within_30=False,
         cluster_id=1,
     )
     assert visit.cluster_id == 1
-    assert not visit.readmit_within_30
 
 
 def test_prediction_result_schema() -> None:


### PR DESCRIPTION
This PR introduces modular feature engineering logic and corresponding tests for the ReadmitRx pipeline. Key features include:

# New Features:
visit_month: extracted from visit_date to capture seasonal risk patterns

chronic_count: aggregate count of chronic conditions based on binary flags

# Tests Added:
Unit tests for add_visit_month, add_chronic_count, and apply_feature_engineering

Validated handling of null values and type safety

# Refactors:
Removed deprecated readmit_within_30 logic from schema and test cases

Updated feature_config.yaml to reflect only valid fields

# Clean CI:
All changes pass black, ruff, mypy, and pytest